### PR TITLE
Added method name to be printed in IL output

### DIFF
--- a/src/IlViewer.Core/IlGeneration.cs
+++ b/src/IlViewer.Core/IlGeneration.cs
@@ -123,6 +123,7 @@ namespace IlViewer.Core
             var output = new List<InstructionResult>();
             foreach(var item in result)
             {
+                output.Add(new InstructionResult {Value = item.Key});
                 foreach(var i in item.Value)
                 {
                     Console.WriteLine(i.ToString());


### PR DESCRIPTION
To increase readability a method name is printed before the IL code so
that it is easier to match the assmebly to high-level code.